### PR TITLE
Make tensorflow an optional dependency (vus[models] extra)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ To ease reproducibility, we share our results over [TSB-UAD](http://chaos.cs.uch
 $ pip install vus
 ```
 
+This installs all core dependencies. TensorFlow-based models (`AE`, `CNN`, `LSTM`) are optional and require an extra install:
+
+```
+$ pip install vus[models]
+```
+
 ### Create Environment and Install Dependencies
 
 ```
@@ -132,6 +138,16 @@ $ git clone https://github.com/johnpaparrizos/VUS
 $ cd VUS/
 $ python setup.py install
 ```
+
+> **Note:** To include TensorFlow-based models when installing from source, use `pip install ".[models]"` instead.
+
+## Optional Dependencies
+
+| Extra | Command | Includes |
+|---|---|---|
+| `models` | `pip install vus[models]` | TensorFlow (`AE`, `CNN`, `LSTM` models) |
+
+Importing `vus.models.AE`, `vus.models.cnn`, or `vus.models.lstm` without the `[models]` extra will raise an `ImportError` with instructions.
 
 ## Experiments
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,7 @@ tslearn>=0.6.3
 cython>=3.0.10
 scikit-learn>=1.3.2
 stumpy>=1.12.0
-tensorflow>=2.13.0
 networkx>=3.1
+
+# optional: pip install vus[models]
+# tensorflow>=2.13.0

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,11 @@ setup(
         'cython>=3.0.10',
         'scikit-learn>=1.3.2',
         'stumpy>=1.12.0',
-        'tensorflow>=2.13.0',
         'networkx>=3.1',
-        ]
+        ],
+    extras_require={
+        'models': [
+            'tensorflow>=2.13.0',
+        ],
+    },
 )

--- a/vus/models/AE.py
+++ b/vus/models/AE.py
@@ -1,8 +1,13 @@
 import numpy as np
 from sklearn.preprocessing import MinMaxScaler
-from tensorflow.keras.models import Sequential
-from tensorflow.keras.callbacks import EarlyStopping
-from tensorflow.keras import layers
+try:
+    from tensorflow.keras.models import Sequential
+    from tensorflow.keras.callbacks import EarlyStopping
+    from tensorflow.keras import layers
+except ImportError:
+    raise ImportError(
+        "TensorFlow is required for vus.models. Install it with: pip install vus[models]"
+    )
 
 
 class AE_MLP2:

--- a/vus/models/cnn.py
+++ b/vus/models/cnn.py
@@ -1,6 +1,11 @@
-from tensorflow.keras.models import Sequential
-from tensorflow.keras.layers import Dense, Conv1D, MaxPooling1D, Flatten, Dropout
-from tensorflow.keras.callbacks import EarlyStopping
+try:
+    from tensorflow.keras.models import Sequential
+    from tensorflow.keras.layers import Dense, Conv1D, MaxPooling1D, Flatten, Dropout
+    from tensorflow.keras.callbacks import EarlyStopping
+except ImportError:
+    raise ImportError(
+        "TensorFlow is required for vus.models. Install it with: pip install vus[models]"
+    )
 
 
 import numpy as np

--- a/vus/models/lstm.py
+++ b/vus/models/lstm.py
@@ -1,7 +1,12 @@
-from tensorflow.keras.models import Sequential
-from tensorflow.keras.layers import Dense
-from tensorflow.keras.layers import LSTM
-from tensorflow.keras.callbacks import EarlyStopping
+try:
+    from tensorflow.keras.models import Sequential
+    from tensorflow.keras.layers import Dense
+    from tensorflow.keras.layers import LSTM
+    from tensorflow.keras.callbacks import EarlyStopping
+except ImportError:
+    raise ImportError(
+        "TensorFlow is required for vus.models. Install it with: pip install vus[models]"
+    )
 
 
 import numpy as np


### PR DESCRIPTION
This PR is addressing issue #6 .

TensorFlow was a mandatory dependency for the whole package, even though it's only needed by three of the baseline detectors under `vus.models`: `lstm.py`, `AE.py`, and `cnn.py`. The metrics themselves, which are the actual contribution of the paper, have no TensorFlow or GPU dependency at all.

This meant every `pip install vus` pulled in TensorFlow, which is a common source of dependency conflicts (TensorFlow/PyTorch/CUDA version mismatches) in projects that don't otherwise use it, even when the only thing needed from `vus` is the evaluation metrics.

This PR moves `tensorflow` out of `install_requires` and into an optional `models` extra. `pip install vus` now installs a lightweight package with just the metrics, and `pip install vus[models]` additionally installs TensorFlow for the three baseline detectors that need it.

This is technically a breaking change for anyone relying on a plain `pip install vus` to also pull in TensorFlow implicitly, but should be a net improvement for most users, who only need the metrics and now get a lighter install with one less source of dependency conflicts.